### PR TITLE
resolves #5 request

### DIFF
--- a/Roth_UI.toc
+++ b/Roth_UI.toc
@@ -3,7 +3,7 @@
 ## Title: Roth UI
 ## Notes: Galaxy's oUF layout with Diablo flavor!
 ## RequiredDeps:
-## SavedVariables: Roth_UI_DB_GLOB, ShinyBuffsDB, PhanxFontDB
+## SavedVariables: Roth_UI_DB_GLOB, ShinyBuffsDB, PhanxFontDB, Roth_UI_DB
 ## SavedVariablesPerCharacter: Roth_UI_DB_CHAR, ShinyBuffsPCDB
 
 embeds\oUF\oUF.xml
@@ -19,6 +19,9 @@ Libs\AceConfig-3.0\AceConfig-3.0.xml
 Libs\LibSharedMedia-3.0\lib.xml
 Libs\AceGUI-3.0-SharedMediaWidgets\widget.xml
 
+init.lua
+
+embeds\Roth_Config\Roth_Config.lua
 
 embeds\rChat\rChat.xml
 embeds\rActionBarStyler\rActionBar.xml

--- a/embeds/RothFont/Addon.lua
+++ b/embeds/RothFont/Addon.lua
@@ -1,25 +1,40 @@
 ﻿local ADDON, Addon = ...
+local addonName, Roth_UI = ...
 local addon, ns = ...
 local cfg = ns.cfg
-if not cfg.embeds.RothFont then return end
-PhanxFontDB = {
-	normal = "Lato",
-	bold   = "Lato Black",
-	scale  = 1,
-}
+local LSM = LibStub("LibSharedMedia-3.0")
 
-local NORMAL       = cfg.font
-local BOLD         = cfg.font
-local BOLDITALIC   = BOLD
-local ITALIC       = NORMAL
-local NUMBER       = BOLD
-local STANDARD     = cfg.chat.font
+local headerFont = LSM:Fetch("font", "")
+local textFont = LSM:Fetch("font", "")
+local chatFont = LSM:Fetch("font", "")
+local headerScale = 1
+local textScale = 1
+local chatScale = 1
+
+if not cfg.embeds.RothFont then return end
 
 ------------------------------------------------------------------------
 if cfg.font == STANDARD_TEXT_FONT then return end
 local function SetFont(obj, font, size, style, r, g, b, sr, sg, sb, sox, soy)
 	if not obj then return end -- TODO: prune things that don't exist anymore
-	obj:SetFont(font, floor(size * PhanxFontDB.scale + 0.5), style)
+	local fontFace = nil
+	local fontScale = 1
+	if font == "text" then
+		fontFace = textFont
+		fontScale = textScale
+	elseif font == "header" then
+		fontFace = headerFont
+		fontScale = headerScale
+	elseif font == "chat" then
+		fontFace = chatFont
+		fontScale = chatScale
+	else
+		print("Unknown font", obj, font, size, style, r, g, b, sr, sg, sb, sox, soy)
+	end
+	if fontScale == nil then
+		fontScale = 1
+	end
+	obj:SetFont(fontFace, floor(size * fontScale), style)
 	if sr and sg and sb then
 		obj:SetShadowColor(sr, sg, sb)
 	end
@@ -34,94 +49,85 @@ local function SetFont(obj, font, size, style, r, g, b, sr, sg, sb, sox, soy)
 end
 
 function Addon:SetFonts(event, addon)
-	NORMAL     = NORMAL
-	BOLD       = BOLD
-	BOLDITALIC = BOLD
-	ITALIC     = NORMAL
-	NUMBER     = BOLD
-
-	UNIT_NAME_FONT     = STANDARD_TEXT_FONT
-	NAMEPLATE_FONT     = STANDARD_TEXT_FONT
-	DAMAGE_TEXT_FONT   = NUMBER
-	
+	SetFont(Tooltip_Med,                        "header", 13)
+	SetFont(Tooltip_Small,                      "text", 12)
+	SetFont(SystemFont_Shadow_Small,            "text", 11) -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Small2,           "text", 11) -- SharedFonts.xml
+	SetFont(SystemFont_Small,                   "text", 12) -- SharedFonts.xml
+	SetFont(SystemFont_Small2,                  "text", 12) -- SharedFonts.xml
+	SetFont(SystemFont_Tiny,                    "text", 11) -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Med1,             "text", 13) -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Med1_Outline,     "text", 12, "OUTLINE") -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Med3,             "header", 15)
+	SetFont(NumberFont_Shadow_Med,              "text", 14)
+	SetFont(NumberFont_Shadow_Small,            "text", 12)
+	SetFont(NumberFont_GameNormal,              "text", 13) -- orig 10 -- inherited by WhiteNormalNumberFont, tekticles = 11
+	SetFont(AchievementFont_Small,              "text", 12)
+	SetFont(ChatBubbleFont,                     "text", 13)
+	SetFont(FriendsFont_Large,                  "header", 15, nil, nil, nil, nil, 0, 0, 0, 1, -1)
+	SetFont(FriendsFont_Normal,                 "text", 13, nil, nil, nil, nil, 0, 0, 0, 1, -1)
+	SetFont(FriendsFont_Small,                  "text", 11, nil, nil, nil, nil, 0, 0, 0, 1, -1)
+	SetFont(FriendsFont_UserText,               "text", 12, nil, nil, nil, nil, 0, 0, 0, 1, -1)
+	SetFont(GameTooltipHeader,                  "header", 15, "OUTLINE") -- SharedFonts.xml
+	SetFont(InvoiceFont_Med,                    "header", 13, nil, 0.15, 0.09, 0.04)
+	SetFont(InvoiceFont_Small,                  "text", 11, nil, 0.15, 0.09, 0.04)
+	SetFont(MailFont_Large,                     "header", 15, nil, 0.15, 0.09, 0.04, 0.54, 0.4, 0.1, 1, -1)
+	SetFont(NumberFont_GameNormal,              "text", 10)
+	SetFont(NumberFont_Normal_Med,              "text", 14)
+	SetFont(NumberFont_Outline_Med,             "text", 15, "OUTLINE")
+	SetFont(NumberFont_OutlineThick_Mono_Small, "text", 13, "OUTLINE")
+	SetFont(ReputationDetailFont,               "text", 12, nil, nil, nil, nil, 0, 0, 0, 1, -1)
+	SetFont(SpellFont_Small,                    "text", 11)
+	SetFont(SystemFont_InverseShadow_Small,     "text", 11)
+	SetFont(SystemFont_Med1,                    "text", 13) -- SharedFonts.xml
+	SetFont(SystemFont_Med3,                    "header", 15)
+	SetFont(SystemFont_Outline,                 "text", 13, "OUTLINE")
+	SetFont(SystemFont_Outline_Small,           "text", 13, "OUTLINE")
+	SetFont(SystemFont_Med2,                    "text", 14, nil, 0.15, 0.09, 0.04)
+	SetFont(SystemFont_Shadow_Med2,             "text", 14) -- SharedFonts.xml
+	SetFont(QuestFontNormalSmall,               "header", 13, nil, nil, nil, nil, 0.54, 0.4, 0.1) -- inherits GameFontBlack
 
 	-- Base fonts in Fonts.xml
-	SetFont(AchievementFont_Small,                BOLD, 12)
-	SetFont(ChatBubbleFont,                     NORMAL, 13)
-	SetFont(CoreAbilityFont,                      BOLD, 32)
-	SetFont(DestinyFontHuge,                      BOLD, 32)
-	SetFont(DestinyFontLarge,                     BOLD, 18)
-	SetFont(FriendsFont_Large,                  NORMAL, 15, nil, nil, nil, nil, 0, 0, 0, 1, -1)
-	SetFont(FriendsFont_Normal,                 NORMAL, 13, nil, nil, nil, nil, 0, 0, 0, 1, -1)
-	SetFont(FriendsFont_Small,                  NORMAL, 11, nil, nil, nil, nil, 0, 0, 0, 1, -1)
-	SetFont(FriendsFont_UserText,               NUMBER, 12, nil, nil, nil, nil, 0, 0, 0, 1, -1)
-	SetFont(Game18Font,                         NORMAL, 18)
-	SetFont(Game24Font,                         NORMAL, 24) -- there are two of these, good job Blizzard
-	SetFont(Game27Font,                         NORMAL, 27)
-	SetFont(Game30Font,                         NORMAL, 30)
-	SetFont(Game32Font,                         NORMAL, 32)
-	SetFont(GameFont_Gigantic,                    BOLD, 32, nil, nil, nil, nil, 0, 0, 0, 1, -1)
-	SetFont(GameTooltipHeader,                    BOLD, 15, "OUTLINE") -- SharedFonts.xml
-	SetFont(InvoiceFont_Med,                    ITALIC, 13, nil, 0.15, 0.09, 0.04)
-	SetFont(InvoiceFont_Small,                  ITALIC, 11, nil, 0.15, 0.09, 0.04)
-	SetFont(MailFont_Large,                     ITALIC, 15, nil, 0.15, 0.09, 0.04, 0.54, 0.4, 0.1, 1, -1)
-	SetFont(NumberFont_GameNormal,              NORMAL, 10)
-	SetFont(NumberFont_Normal_Med,              NUMBER, 14)
-	SetFont(NumberFont_Outline_Huge,            NUMBER, 30, "THICKOUTLINE", 30)
-	SetFont(NumberFont_Outline_Large,           NUMBER, 17, "OUTLINE")
-	SetFont(NumberFont_Outline_Med,             NUMBER, 15, "OUTLINE")
-	SetFont(NumberFont_OutlineThick_Mono_Small, NUMBER, 13, "OUTLINE")
-	SetFont(NumberFont_Shadow_Med,              NORMAL, 14)
-	SetFont(NumberFont_Shadow_Small,            NORMAL, 12)
-	SetFont(NumberFont_GameNormal,              NORMAL, 13) -- orig 10 -- inherited by WhiteNormalNumberFont, tekticles = 11
-	SetFont(QuestFont_Enormous,                   BOLD, 30)
-	SetFont(QuestFont_Huge,                       BOLD, 19)
-	SetFont(QuestFont_Large,                    NORMAL, 16) -- SharedFonts.xml
-	SetFont(QuestFont_Shadow_Huge,                BOLD, 19, nil, nil, nil, nil, 0.54, 0.4, 0.1)
-	SetFont(QuestFont_Shadow_Small,             NORMAL, 16)
-	SetFont(QuestFont_Super_Huge,                 BOLD, 24)
-	SetFont(QuestFont_Super_Huge_Outline,         BOLD, 24, "OUTLINE")
-	SetFont(ReputationDetailFont,                 BOLD, 12, nil, nil, nil, nil, 0, 0, 0, 1, -1)
-	SetFont(SpellFont_Small,                      BOLD, 11)
-	SetFont(SplashHeaderFont,                     BOLD, 24)
-	SetFont(SystemFont_Huge1,                   NORMAL, 20)
-	SetFont(SystemFont_Huge1_Outline,           NORMAL, 20, "OUTLINE")
-	SetFont(SystemFont_InverseShadow_Small,       BOLD, 11)
-	SetFont(SystemFont_Large,                   NORMAL, 17)
-	SetFont(SystemFont_Med1,                    NORMAL, 13) -- SharedFonts.xml
-	SetFont(SystemFont_Med2,                    ITALIC, 14, nil, 0.15, 0.09, 0.04)
-	SetFont(SystemFont_Med3,                    NORMAL, 15)
-	SetFont(SystemFont_Outline,                 NUMBER, 13, "OUTLINE")
-	SetFont(SystemFont_Outline_Small,           NUMBER, 13, "OUTLINE")
-	SetFont(SystemFont_OutlineThick_Huge2,      NORMAL, 22, "THICKOUTLINE")
-	SetFont(SystemFont_OutlineThick_Huge4,  BOLDITALIC, 27, "THICKOUTLINE")
-	SetFont(SystemFont_OutlineThick_WTF,    BOLDITALIC, 31, "THICKOUTLINE", nil, nil, nil, 0, 0, 0, 1, -1)
-	SetFont(SystemFont_OutlineThick_WTF2,   BOLDITALIC, 36) -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Huge1,              BOLD, 20) -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Huge2,              BOLD, 24) -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Huge3,              BOLD, 25) -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Large,            NORMAL, 17) -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Large2,           NORMAL, 19) -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Large_Outline,    NORMAL, 17, "OUTLINE") -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Med1,             NORMAL, 13) -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Med1_Outline,     NORMAL, 12, "OUTLINE") -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Med2,             NORMAL, 14) -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Med3,             NORMAL, 15)
-	SetFont(SystemFont_Shadow_Outline_Huge2,    NORMAL, 22, "OUTLINE") -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Small,            NORMAL, 11) -- SharedFonts.xml
-	SetFont(SystemFont_Shadow_Small2,           NORMAL, 11) -- SharedFonts.xml
-	SetFont(SystemFont_Small,                   NORMAL, 12) -- SharedFonts.xml
-	SetFont(SystemFont_Small2,                  NORMAL, 12) -- SharedFonts.xml
-	SetFont(SystemFont_Tiny,                    NORMAL, 11) -- SharedFonts.xml
-	SetFont(Tooltip_Med,                        NORMAL, 13)
-	SetFont(Tooltip_Small,                        BOLD, 12)
+	SetFont(CoreAbilityFont,                      "header", 32)
+	SetFont(DestinyFontHuge,                      "header", 32)
+	SetFont(DestinyFontLarge,                     "header", 18)
+	SetFont(Game18Font,                         "text", 18)
+	SetFont(Game24Font,                         "text", 24) -- there are two of these, good job Blizzard
+	SetFont(Game27Font,                         "header", 27)
+	SetFont(Game30Font,                         "header", 30)
+	SetFont(Game32Font,                         "header", 32)
+	SetFont(GameFont_Gigantic,                    "header", 32, nil, nil, nil, nil, 0, 0, 0, 1, -1)
+	SetFont(NumberFont_Outline_Huge,            "text", 30, "THICKOUTLINE", 30)
+	SetFont(NumberFont_Outline_Large,           "text", 17, "OUTLINE")
+	SetFont(QuestFont_Enormous,                   "header", 30)
+	SetFont(QuestFont_Huge,                       "header", 19)
+	SetFont(QuestFont_Large,                    "header", 16) -- SharedFonts.xml
+	SetFont(QuestFont_Shadow_Huge,                "header", 19, nil, nil, nil, nil, 0.54, 0.4, 0.1)
+	SetFont(QuestFont_Shadow_Small,             "text", 16)
+	SetFont(QuestFont_Super_Huge,                 "header", 24)
+	SetFont(QuestFont_Super_Huge_Outline,         "header", 24, "OUTLINE")
+	SetFont(SplashHeaderFont,                     "header", 24)
+	SetFont(SystemFont_Huge1,                   "header", 20)
+	SetFont(SystemFont_Huge1_Outline,           "header", 20, "OUTLINE")
+	SetFont(SystemFont_Large,                   "header", 17)
+	SetFont(SystemFont_OutlineThick_Huge2,      "header", 22, "THICKOUTLINE")
+	SetFont(SystemFont_OutlineThick_Huge4,  "header", 27, "THICKOUTLINE")
+	SetFont(SystemFont_OutlineThick_WTF,    "header", 31, "THICKOUTLINE", nil, nil, nil, 0, 0, 0, 1, -1)
+	SetFont(SystemFont_OutlineThick_WTF2,   "header", 36) -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Huge1,              "header", 20) -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Huge2,              "header", 24) -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Huge3,              "header", 25) -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Large,            "header", 17) -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Large2,           "header", 19) -- SharedFonts.xml
+	SetFont(SystemFont_Shadow_Large_Outline,    "header", 17, "OUTLINE") -- SharedFonts.xml
+
+	SetFont(SystemFont_Shadow_Outline_Huge2,    "text", 22, "OUTLINE") -- SharedFonts.xml
 
 	-- Derived fonts in FontStyles.xml
-	SetFont(BossEmoteNormalHuge,  BOLDITALIC, 27, "THICKOUTLINE") -- inherits SystemFont_Shadow_Huge3
-	SetFont(CombatTextFont,           NORMAL, 26) -- inherits SystemFont_Shadow_Huge3
-	SetFont(ErrorFont,                ITALIC, 16, nil, 60) -- inherits GameFontNormalLarge
-	SetFont(QuestFontNormalSmall,       BOLD, 13, nil, nil, nil, nil, 0.54, 0.4, 0.1) -- inherits GameFontBlack
-	SetFont(WorldMapTextFont,     BOLDITALIC, 31, "THICKOUTLINE", 40, nil, nil, 0, 0, 0, 1, -1) -- inherits SystemFont_OutlineThick_WTF
+	SetFont(BossEmoteNormalHuge,  "header", 27, "THICKOUTLINE") -- inherits SystemFont_Shadow_Huge3
+	SetFont(CombatTextFont,           "text", 26) -- inherits SystemFont_Shadow_Huge3
+	SetFont(ErrorFont,                "text", 16, nil, 60) -- inherits GameFontNormalLarge
+	SetFont(WorldMapTextFont,     "header", 31, "THICKOUTLINE", 40, nil, nil, 0, 0, 0, 1, -1) -- inherits SystemFont_OutlineThick_WTF
 
 	--[[ Fancy stuff!
 	SetFont(ZoneTextFont,           BOLD, 31, "THICKOUTLINE") -- inherits SystemFont_OutlineThick_WTF
@@ -135,14 +141,65 @@ function Addon:SetFonts(event, addon)
 end
 
 ------------------------------------------------------------------------
+hooksecurefunc("FCF_SetChatWindowFontSize", function(self, frame, size)
+	if not frame then
+		frame = FCF_GetCurrentChatFrame()
+	end
+	if not size then
+		size = self.value
+	end
 
-local f = CreateFrame("Frame", "PhanxFont")
-f:RegisterEvent("ADDON_LOADED")
-f:SetScript("OnEvent", function(self, event, addon)
+	-- Set all the other frames to the same size.
+	for i = 1, 10 do
+		local f = _G["ChatFrame"..i]
+		if f then
+			f:SetFont("chat", size)
+			SetChatWindowSize(i, size)
+		end
+	end
+
+	-- Set the language override fonts to the same size.
+	for _, f in pairs({
+		ChatFontNormalKO,
+		ChatFontNormalRU,
+		ChatFontNormalZH,
+	}) do
+		local font, _, outline = f:GetFont()
+		f:SetFont("chat", size, outline)
+	end
+end)
+
+hooksecurefunc("BattlePetToolTip_Show", function()
+	BattlePetTooltip:SetHeight(BattlePetTooltip:GetHeight() + 12)
+end)
+
+hooksecurefunc("FloatingBattlePet_Show", function()
+	FloatingBattlePetTooltip:SetHeight(FloatingBattlePetTooltip:GetHeight() + 12)
+end)
+
+
+--- We may be using fonts that haven't loaded yet, so listen for them.
+Roth_UI:ListenForMediaChange(function(name, mediaType, key)
+	if mediaType == "font" then
+		headerFont = LSM:Fetch("font", Roth_UI.db.profile.headerFont)
+		textFont = LSM:Fetch("font", Roth_UI.db.profile.textFont)
+		chatFont = LSM:Fetch("font", Roth_UI.db.profile.chatFont)
+		Addon:SetFonts()
+	end
+end)
+
+--- Need to set chat fonts as soon as the addon has loaded.
+Roth_UI:ListenForLoaded(function()
+	headerFont = LSM:Fetch("font", Roth_UI.db.profile.headerFont)
+	textFont = LSM:Fetch("font", Roth_UI.db.profile.textFont)
+	chatFont = LSM:Fetch("font", Roth_UI.db.profile.chatFont)
+	headerScale = ns.db.profile.headerScale
+	textScale = ns.db.profile.textScale
+	chatScale = ns.db.profile.chatScale
+	Addon:SetFonts()
+
 	UIDROPDOWNMENU_DEFAULT_TEXT_HEIGHT = 14
 	CHAT_FONT_HEIGHTS = { 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24 }
-
-	Addon:SetFonts()
 
 	-- I have no idea why the channel list is getting fucked up
 	-- but re-setting the font obj seems to fix it
@@ -164,40 +221,5 @@ f:SetScript("OnEvent", function(self, event, addon)
 
 	LFGListFrame.CategorySelection.CategoryButtons[1].Label:SetFontObject(GameFontNormal)
 	WorldMapFrameNavBarHomeButtonText:SetFontObject(GameFontNormal)
-end)
 
-hooksecurefunc("FCF_SetChatWindowFontSize", function(self, frame, size)
-	if not frame then
-		frame = FCF_GetCurrentChatFrame()
-	end
-	if not size then
-		size = self.value
-	end
-
-	-- Set all the other frames to the same size.
-	for i = 1, 10 do
-		local f = _G["ChatFrame"..i]
-		if f then
-			f:SetFont(STANDARD, size)
-			SetChatWindowSize(i, size)
-		end
-	end
-
-	-- Set the language override fonts to the same size.
-	for _, f in pairs({
-		ChatFontNormalKO,
-		ChatFontNormalRU,
-		ChatFontNormalZH,
-	}) do
-		local font, _, outline = f:GetFont()
-		f:SetFont(font, size, outline)
-	end
-end)
-
-hooksecurefunc("BattlePetToolTip_Show", function()
-	BattlePetTooltip:SetHeight(BattlePetTooltip:GetHeight() + 12)
-end)
-
-hooksecurefunc("FloatingBattlePet_Show", function()
-	FloatingBattlePetTooltip:SetHeight(FloatingBattlePetTooltip:GetHeight() + 12)
 end)

--- a/embeds/RothFont/Config.lua
+++ b/embeds/RothFont/Config.lua
@@ -1,0 +1,121 @@
+local addonName, Roth_UI = ...
+local LSM = LibStub("LibSharedMedia-3.0")
+local fonts = AceGUIWidgetLSMlists.font
+
+-- Font options
+local fonts = {
+  type = "group",
+  name = "Fonts",
+  order = 1,
+  args = {
+    headerFont = {
+      type = "select",
+      order = 1,
+      name = "Header Font",
+      dialogControl = 'LSM30_Font',
+      desc = "Select the font you'd like to use for large displays, like character names, titles and headers",
+      values = fonts, -- this table needs to be a list of keys found in the sharedmedia type you want
+      get = function()
+        return Roth_UI.db.profile.headerFont -- variable that is my current selection
+      end,
+      set = function(self,key)
+        print("setting")
+        Roth_UI.db.profile.headerFont = key -- saves our new selection the the current one
+      end,
+    },
+    headerScale = {
+      type = "range",
+      order = 2,
+      name = "Header Font Scale",
+      desc = "Header Font Scale relative to WoW defaults",
+      min = 0.5,
+      max = 2.5,
+      softMin = 0.75,
+      softMax = 1.5,
+      step = 0.01,
+      bigStep = 0.05,
+      get = function()
+        return Roth_UI.db.profile.headerScale
+      end,
+      set = function(self, key)
+        Roth_UI.db.profile.headerScale = key
+      end,
+    },
+    textFont = {
+      type = "select",
+      order = 3,
+      name = "Text Font",
+      dialogControl = 'LSM30_Font',
+      desc = "Select the font you'd like to use for detail information, like class strings, quest text and cooldowns",
+      values = fonts, -- this table needs to be a list of keys found in the sharedmedia type you want
+      get = function()
+        return Roth_UI.db.profile.textFont -- variable that is my current selection
+      end,
+      set = function(self,key)
+        Roth_UI.db.profile.textFont = key -- saves our new selection the the current one
+      end,
+    },
+    textScale = {
+      type = "range",
+      order = 4,
+      name = "Text Font Scale",
+      desc = "Text Font Scale relative to WoW defaults",
+      min = 0.5,
+      max = 2.5,
+      softMin = 0.75,
+      softMax = 1.5,
+      step = 0.01,
+      bigStep = 0.05,
+      get = function()
+        return Roth_UI.db.profile.textScale
+      end,
+      set = function(self, key)
+        Roth_UI.db.profile.textScale = key
+      end,
+    },
+    chat = {
+      type = "select",
+      order = 5,
+      name = "Chat Font",
+      dialogControl = 'LSM30_Font',
+      desc = "Select the font you'd like to use for chat",
+      values = AceGUIWidgetLSMlists.font, -- this table needs to be a list of keys found in the sharedmedia type you want
+      get = function()
+        return Roth_UI.db.profile.chatFont -- variable that is my current selection
+      end,
+      set = function(self,key)
+        Roth_UI.db.profile.chatFont = key -- saves our new selection the the current one
+      end,
+    },
+    chatScale = {
+      type = "range",
+      order = 6,
+      name = "Chat Font Scale",
+      desc = "Chat Font Scale relative to WoW defaults",
+      min = 0.5,
+      max = 2.5,
+      softMin = 0.75,
+      softMax = 1.5,
+      step = 0.01,
+      bigStep = 0.05,
+      get = function()
+        return Roth_UI.db.profile.chatScale
+      end,
+      set = function(self, key)
+        Roth_UI.db.profile.chatScale = key
+      end,
+    },
+  }
+}
+
+-- Users likely wouldn't want to have different fonts for different characters.
+local profileDefaults = {
+  headerFont = "Cracked",
+  headerScale = 1.0,
+  textFont = "Cracked",
+  textScale = 1.0,
+  chatFont = "Cracked",
+  chatScale = 1.0,
+}
+
+Roth_UI:AddConfig("fonts", fonts, profileDefaults)

--- a/embeds/RothFont/font.xml
+++ b/embeds/RothFont/font.xml
@@ -1,4 +1,4 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
 	<Script file='Addon.lua' />
-	
+	<Script file='Config.lua' />
 </Ui>

--- a/embeds/Roth_Config/Roth_Config.lua
+++ b/embeds/Roth_Config/Roth_Config.lua
@@ -1,0 +1,45 @@
+local addonName, Roth_UI = ...
+local LSM = LibStub("LibSharedMedia-3.0")
+local fonts = AceGUIWidgetLSMlists.font
+local order = 1
+local options = {
+  type = "group",
+  args = {}
+}
+
+local defaults = {
+  profile = {},
+  char = {}
+}
+
+--- Method to add module configuration into the Roth UI config block.
+--  This method should not be invoked after LoadConfig has been called.
+--  @param key The option key to add the local options to the options table.
+--  @param newOptions The new options to add
+--  @param profileDefaults Any defaults to be added at the profile level.
+--  @param characterDefaults Any defaults to be added at the character level.
+function Roth_UI:AddConfig(key, newOptions, profileDefaults, characterDefaults)
+  newOptions.order = order
+  if profileDefaults then
+    for k,v in pairs(profileDefaults) do defaults.profile[k] = v end
+  end
+  if characterDefaults then
+    for k,v in pairs(characterDefaults) do defaults.char[k] = v end
+  end
+  options.args[key] = newOptions
+  order = order + 1
+end
+
+--- Method to both load configuration from the SavedVariables and initialize the options window.
+function Roth_UI:LoadConfig()
+  Roth_UI.db = LibStub("AceDB-3.0"):New("Roth_UI_DB", defaults)
+  Roth_UI.db.RegisterCallback(Roth_UI, "OnProfileChanged", function()
+    ReloadUI()
+  end)
+  options.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(Roth_UI.db)
+  LibStub("AceConfig-3.0"):RegisterOptionsTable("Roth_Config", options, {"roth_config"})
+  -- TODO Need to have this open up via slash command
+  local OpenFunc = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("Roth_Config", "Roth UI")
+  -- This is to handle the situation where a reload happens...want to make sure we restart at order 1
+  order = 1
+end

--- a/embeds/Roth_Config/Roth_Config.xml
+++ b/embeds/Roth_Config/Roth_Config.xml
@@ -1,0 +1,3 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/">
+	<Script file='Roth_Config.lua' />
+</Ui>

--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,37 @@
+local addonName, Roth_UI = ...
+local LSM = LibStub("LibSharedMedia-3.0")
+
+local mediaCallbacks = {}
+local loadedCallbacks = {}
+local configLoaded = false
+
+local LoadedHandler = CreateFrame("Frame")
+LoadedHandler:RegisterEvent("ADDON_LOADED")
+LoadedHandler:SetScript("OnEvent", function(self, event, name)
+  if name == "Roth_UI" then
+    Roth_UI:LoadConfig()
+    configLoaded = true
+    for index, callback in pairs(loadedCallbacks) do
+      callback()
+    end
+  end
+end)
+
+--- Callback to get notifications when addons loaded later than us have added shared media.
+LSM.RegisterCallback(Roth_UI, "LibSharedMedia_Registered", function(name, mediaType, key)
+  if configLoaded then
+    for index, callback in pairs(mediaCallbacks) do
+      callback(name, mediaType, key)
+    end
+  end
+end)
+
+
+--- Allows a callback to be registered for when LibSharedMedia registers new content
+function Roth_UI:ListenForMediaChange(callback)
+  table.insert(mediaCallbacks, callback)
+end
+
+function Roth_UI:ListenForLoaded(callback)
+  table.insert(loadedCallbacks, callback)
+end


### PR DESCRIPTION
Okay, here's an actual pull request to resolve #5 .  LibSharedMedia, or rather CallbackHandler, binds the callback to your namespace, so getting multiple sharedmedia callbacks was getting rough.  However, I've got a couple of methods to implement observer patterns and fire callbacks to cut down on boilerplate code. In addition, addons can provide their own config to be shown, which should make it so that the config for a module lives with the module instead of being centralized.

Note that this will only change the fonts in the RothFonts package, which should be the system level fonts.  rChat and rTooltip are great next places to update config.

Let me know what you think and I can iterate from here, then move on to other modules once we're good with the system fonts.
